### PR TITLE
Fix logging warnings

### DIFF
--- a/gym-donkeycar/gym_donkeycar/core/client.py
+++ b/gym-donkeycar/gym_donkeycar/core/client.py
@@ -100,7 +100,7 @@ class SDClient:
                     try:
                         data = s.recv(1024 * 256)
                     except ConnectionAbortedError:
-                        logger.warn("socket connection aborted")
+                        logger.warning("socket connection aborted")
                         print("socket connection aborted")
                         self.do_process_msgs = False
                         break

--- a/gym-donkeycar/gym_donkeycar/envs/donkey_sim.py
+++ b/gym-donkeycar/gym_donkeycar/envs/donkey_sim.py
@@ -382,7 +382,7 @@ class DonkeyUnitySimHandler(IMesgHandler):
 
     def on_recv_message(self, message: Dict[str, Any]) -> None:
         if "msg_type" not in message:
-            logger.warn("expected msg_type field")
+            logger.warning("expected msg_type field")
             return
         msg_type = message["msg_type"]
         logger.debug("got message :" + msg_type)
@@ -394,7 +394,7 @@ class DonkeyUnitySimHandler(IMesgHandler):
     # ------- Env interface ---------- #
 
     def reset(self) -> None:
-        logger.debug("reseting")
+        logger.debug("resetting")
         self.send_reset_car()
         self.timer.reset()
         time.sleep(1)

--- a/stable-baselines3/stable_baselines3/common/vec_env/vec_video_recorder.py
+++ b/stable-baselines3/stable_baselines3/common/vec_env/vec_video_recorder.py
@@ -117,7 +117,7 @@ class VecVideoRecorder(VecEnvWrapper):
             self.recorded_frames.append(frame)
         else:
             self._stop_recording()
-            logger.warn(
+            logger.warning(
                 f"Recording stopped: expected type of frame returned by render to be a numpy array, got instead {type(frame)}."
             )
 
@@ -139,7 +139,7 @@ class VecVideoRecorder(VecEnvWrapper):
         assert self.recording, "_stop_recording was called, but no recording was started"
 
         if len(self.recorded_frames) == 0:  # pragma: no cover
-            logger.warn("Ignored saving a video as there were zero frames to save.")
+            logger.warning("Ignored saving a video as there were zero frames to save.")
         else:
             from moviepy.video.io.ImageSequenceClip import ImageSequenceClip
 
@@ -152,4 +152,4 @@ class VecVideoRecorder(VecEnvWrapper):
     def __del__(self) -> None:
         """Warn the user in case last video wasn't saved."""
         if len(self.recorded_frames) > 0:  # pragma: no cover
-            logger.warn("Unable to save last video! Did you call close()?")
+            logger.warning("Unable to save last video! Did you call close()?")


### PR DESCRIPTION
## Summary
- use `logger.warning` instead of deprecated `logger.warn`
- fix spelling in debug message

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gym')*

------
https://chatgpt.com/codex/tasks/task_e_6843ff3bd6188326bb45b9c050f75d51