### PR TITLE
Add training helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # RCAutoPilot
+
+This repository bundles [RL Baselines3 Zoo](https://github.com/DLR-RM/rl-baselines3-zoo), [Stable Baselines3](https://github.com/DLR-RM/stable-baselines3) and [gym-donkeycar](https://github.com/tawnkramer/gym-donkeycar) to train autonomous driving agents.
+
+## Quick Start
+
+1. **Install dependencies** (recommended inside a virtual environment):
+
+   ```bash
+   apt-get install swig cmake ffmpeg
+   pip install -r rl-baselines3-zoo/requirements.txt
+   pip install -e rl-baselines3-zoo
+   pip install -e gym-donkeycar
+   ```
+
+   Optionally install extra tools for plotting and tests:
+
+   ```bash
+   pip install -e rl-baselines3-zoo[plots,tests]
+   ```
+
+2. **Launch the DonkeyCar simulator**. If you have the simulator installed, start it manually or via script before training.
+
+3. **Run training** using the helper script:
+
+   ```bash
+   ./start_training.sh
+   ```
+
+   The script runs RL Baselines3 Zoo with the SAC algorithm on the `donkey-generated-track-v0` environment. Additional arguments will be forwarded to `train.py`.
+

--- a/start_training.sh
+++ b/start_training.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Start RL Baselines3 Zoo training for DonkeyCar
+# Usage: ./start_training.sh [additional train.py arguments]
+
+set -e
+
+# Move to the rl-baselines3-zoo directory
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/rl-baselines3-zoo"
+
+python train.py --algo sac --env donkey-generated-track-v0 --eval-freq 10000 --eval-episodes 10 --n-eval-envs 1 "$@"


### PR DESCRIPTION
## Summary
- add convenience script `start_training.sh` to run RL Baselines3 Zoo
- expand README with setup and single-command training instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gym')*

------
https://chatgpt.com/codex/tasks/task_e_684404c6d0cc8326a77d7e7aded67904