### PR TITLE
Add environment setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,17 @@ This repository bundles [RL Baselines3 Zoo](https://github.com/DLR-RM/rl-baselin
 
 ## Quick Start
 
-1. **Install dependencies** (recommended inside a virtual environment):
+1. **Create a Python environment and install dependencies**:
+
+   Run the setup script which creates a virtual environment in `venv`, activates
+   it and installs all required packages.
 
    ```bash
-   apt-get install swig cmake ffmpeg
-   pip install -r rl-baselines3-zoo/requirements.txt
-   pip install -e rl-baselines3-zoo
-   pip install -e gym-donkeycar
+   source ./setup_env.sh
    ```
 
-   Optionally install extra tools for plotting and tests:
+   Optionally install extra tools for plotting and tests after the environment
+   is activated:
 
    ```bash
    pip install -e rl-baselines3-zoo[plots,tests]

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Create Python virtual environment and install dependencies.
+# Source this script to keep the environment active.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)"
+cd "$SCRIPT_DIR"
+
+if [ ! -d "venv" ]; then
+    python3 -m venv venv
+fi
+
+# Activate the environment
+# shellcheck disable=SC1091
+source venv/bin/activate
+
+# Upgrade pip
+pip install --upgrade pip
+
+# Install system packages (may require sudo)
+apt-get update
+apt-get install -y swig cmake ffmpeg
+
+# Install Python dependencies
+pip install -r rl-baselines3-zoo/requirements.txt
+pip install -e rl-baselines3-zoo
+pip install -e gym-donkeycar
+
+echo "Environment ready and activated. Use 'deactivate' to exit."


### PR DESCRIPTION
## Summary
- add helper script to create a `venv` and install dependencies
- document how to use `setup_env.sh` in the quick start

## Testing
- `bash -n setup_env.sh`


------
https://chatgpt.com/codex/tasks/task_e_684406c75b54832686076867fa695faf