### PR TITLE
Fix training with DonkeyCar env

### DIFF
--- a/start_training.sh
+++ b/start_training.sh
@@ -8,4 +8,5 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR/rl-baselines3-zoo"
 
-python train.py --algo sac --env donkey-generated-track-v0 --eval-freq 10000 --eval-episodes 10 --n-eval-envs 1 "$@"
+python train.py --algo sac --env donkey-generated-track-v0 --gym-packages gym_donkeycar \
+       --eval-freq 10000 --eval-episodes 10 --n-eval-envs 1 "$@"


### PR DESCRIPTION
## Summary
- ensure `gym_donkeycar` is imported when training

## Testing
- `pytest -q` *(fails: 38 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68440ba126e48326b9d9250dd8be670e