### PR TITLE
Fix gym-donkeycar path for training script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,8 @@ This repository bundles [RL Baselines3 Zoo](https://github.com/DLR-RM/rl-baselin
 
    The script runs RL Baselines3 Zoo with the SAC algorithm on the `donkey-generated-track-v0` environment. Additional arguments will be forwarded to `train.py`.
 
+   If you encounter an error about `donkey-generated-track-v0` not being found,
+   make sure the `gym-donkeycar` package is installed (the setup script installs
+   it automatically) or run training via `./start_training.sh` which adds the
+   package to the `PYTHONPATH`.
+

--- a/start_training.sh
+++ b/start_training.sh
@@ -8,5 +8,9 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR/rl-baselines3-zoo"
 
+# Ensure the local gym-donkeycar package is on the Python path so
+# its environments get registered even if it has not been installed.
+export PYTHONPATH="$SCRIPT_DIR/gym-donkeycar${PYTHONPATH:+:$PYTHONPATH}"
+
 python train.py --algo sac --env donkey-generated-track-v0 --gym-packages gym_donkeycar \
        --eval-freq 10000 --eval-episodes 10 --n-eval-envs 1 "$@"


### PR DESCRIPTION
## Summary
- ensure gym-donkeycar is on `PYTHONPATH` in `start_training.sh`
- document fix for missing environment in README

## Testing
- `bash -n start_training.sh`

------
https://chatgpt.com/codex/tasks/task_e_68442f27e6f08326ae14c49a8a19642a