### PR TITLE
Fix permission issue in setup script

### DIFF
--- a/setup_software.sh
+++ b/setup_software.sh
@@ -1,7 +1,14 @@
-
-
-
+#!/bin/bash
 # Install system packages (may require sudo)
+set -e
+
 apt-get update
 apt-get install -y swig cmake ffmpeg
-sudo chown -R $USER:$USER rl-baselines3-zoo
+
+# Ensure the rl-baselines3-zoo directory is owned by the invoking user
+OWNER="${SUDO_USER:-$USER}"
+if [ "$(id -u)" -eq 0 ]; then
+    chown -R "$OWNER":"$OWNER" rl-baselines3-zoo
+else
+    sudo chown -R "$OWNER":"$OWNER" rl-baselines3-zoo
+fi


### PR DESCRIPTION
## Summary
- ensure `setup_software.sh` sets correct directory ownership

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gym')*

------
https://chatgpt.com/codex/tasks/task_e_684433dd35fc832687fd516eea88c480