### PR TITLE
Fix donkeycar env registration for Gymnasium

### DIFF
--- a/gym-donkeycar/README.md
+++ b/gym-donkeycar/README.md
@@ -24,7 +24,7 @@ but want to understand this one. Simple example code:
 
 ```python
 import os
-import gym
+import gymnasium as gym
 import gym_donkeycar
 import numpy as np
 
@@ -52,7 +52,7 @@ env.close()
 or if you already launched the simulator:
 
 ```python
-import gym
+import gymnasium as gym
 import numpy as np
 
 import gym_donkeycar

--- a/gym-donkeycar/gym_donkeycar/__init__.py
+++ b/gym-donkeycar/gym_donkeycar/__init__.py
@@ -1,7 +1,7 @@
 """Top-level package for OpenAI Gym Environments for Donkey Car."""
 import os
 
-from gym.envs.registration import register
+from gymnasium.envs.registration import register
 
 from gym_donkeycar.envs.donkey_env import (
     AvcSparkfunEnv,

--- a/gym-donkeycar/gym_donkeycar/envs/donkey_env.py
+++ b/gym-donkeycar/gym_donkeycar/envs/donkey_env.py
@@ -7,10 +7,10 @@ import logging
 import time
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-import gym
+import gymnasium as gym
 import numpy as np
-from gym import spaces
-from gym.utils import seeding
+from gymnasium import spaces
+from gymnasium.utils import seeding
 
 from gym_donkeycar.envs.donkey_proc import DonkeyUnityProcess
 from gym_donkeycar.envs.donkey_sim import DonkeyUnitySimContoller

--- a/gym-donkeycar/setup.py
+++ b/gym-donkeycar/setup.py
@@ -15,8 +15,8 @@ with open("README.md") as readme_file:
 with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
-# gym 0.26 introduces breaking changes that are supported here
-requirements = ["gym>=0.26.2", "numpy", "pillow"]
+# Use gymnasium which replaced gym
+requirements = ["gymnasium>=0.29.1", "numpy", "pillow"]
 
 
 setup(

--- a/gym-donkeycar/tests/test_gym_donkeycar.py
+++ b/gym-donkeycar/tests/test_gym_donkeycar.py
@@ -3,7 +3,7 @@
 
 """Tests for `gym_donkeycar` package."""
 
-import gym
+import gymnasium as gym
 
 env_list = [
     "donkey-warehouse-v0",

--- a/rl-baselines3-zoo/requirements.txt
+++ b/rl-baselines3-zoo/requirements.txt
@@ -1,4 +1,4 @@
-gym==0.26.2
+gymnasium>=0.29.1
 stable-baselines3[extra,tests,docs]>=2.6.1a1,<3.0
 box2d-py==2.3.8
 pybullet_envs_gymnasium>=0.6.0


### PR DESCRIPTION
## Summary
- update gym-donkeycar package to register envs with `gymnasium`
- change donkey environment implementation and example code to import `gymnasium`
- require `gymnasium` instead of `gym`
- adapt tests and RL Zoo requirements

## Testing
- `make test` in `gym-donkeycar` *(fails: ModuleNotFoundError: No module named 'gymnasium')*
- `make pytest` in `rl-baselines3-zoo` *(fails: unrecognized arguments: --cov-config)*
- `make pytest` in `stable-baselines3` *(fails: unrecognized arguments: --cov-config)*

------
https://chatgpt.com/codex/tasks/task_e_6844376552ac8326874e1b21c5072055