### PR TITLE
Add gymnasium dependency check

### DIFF
--- a/start_training.sh
+++ b/start_training.sh
@@ -8,9 +8,20 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR/rl-baselines3-zoo"
 
+
 # Ensure the local gym-donkeycar package is on the Python path so
 # its environments get registered even if it has not been installed.
 export PYTHONPATH="$SCRIPT_DIR/gym-donkeycar${PYTHONPATH:+:$PYTHONPATH}"
+
+# Check that gymnasium is installed. The RL Zoo and gym-donkeycar
+# environments rely on it and importing wrappers will fail otherwise.
+if ! python - <<'EOF' >/dev/null 2>&1
+import gymnasium.wrappers.time_limit
+EOF
+then
+    echo "Error: gymnasium is not installed. Please run 'source ./setup_env.sh'" >&2
+    exit 1
+fi
 
 python train.py --algo sac --env donkey-generated-track-v0 --gym-packages gym_donkeycar \
        --eval-freq 10000 --eval-episodes 10 --n-eval-envs 1 "$@"


### PR DESCRIPTION
## Summary
- update training script to detect missing `gymnasium` and prompt to run setup

## Testing
- `./start_training.sh --help | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68443d7c248883268a4a63754e8e2383