### PR TITLE
Add transformer training option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ This repository bundles [RL Baselines3 Zoo](https://github.com/DLR-RM/rl-baselin
   a checkpoint every epoch (change the interval with `--checkpoint-freq`). If an
   existing file contains only model weights, the script will still load them but
   the optimizer state will start from scratch. The model weights are periodically saved to
-  `rl-baselines3-zoo/donkey_transformer.pt` by default. Use `--model-path` to
-  change the location and `--save-freq` to control the saving interval.
+  `rl-baselines3-zoo/donkey_transformer.pt` (relative to the repository root)
+  by default. Use `--model-path` to change the location and `--save-freq` to
+  control the saving interval.
   When training starts, the script automatically reloads weights from the last
   saved file if present.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ This repository bundles [RL Baselines3 Zoo](https://github.com/DLR-RM/rl-baselin
    ```
 
    By default, the example trains for 10 epochs. Pass `--epochs <n>` after
-   `--transformer` to change the number of epochs.
+   `--transformer` to change the number of epochs. You can also save and
+   resume training with `--checkpoint <file>` which stores a checkpoint every
+   epoch (change the interval with `--checkpoint-freq`).
 
    If you encounter an error about `donkey-generated-track-v0` not being found,
    ensure the `gym-donkeycar` package is available. The provided scripts add it

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ This repository bundles [RL Baselines3 Zoo](https://github.com/DLR-RM/rl-baselin
    ./start_training.sh --transformer
    ```
 
+   By default, the example trains for 10 epochs. Pass `--epochs <n>` after
+   `--transformer` to change the number of epochs.
+
    If you encounter an error about `donkey-generated-track-v0` not being found,
    ensure the `gym-donkeycar` package is available. The provided scripts add it
    to the `PYTHONPATH` and the transformer example imports it automatically so

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This repository bundles [RL Baselines3 Zoo](https://github.com/DLR-RM/rl-baselin
    ```
 
    If you encounter an error about `donkey-generated-track-v0` not being found,
-   make sure the `gym-donkeycar` package is installed (the setup script installs
-   it automatically) or run training via `./start_training.sh` which adds the
-   package to the `PYTHONPATH`.
+   ensure the `gym-donkeycar` package is available. The provided scripts add it
+   to the `PYTHONPATH` and the transformer example imports it automatically so
+   environments are registered.
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ This repository bundles [RL Baselines3 Zoo](https://github.com/DLR-RM/rl-baselin
   By default, the example trains continuously until interrupted. Pass
   `--epochs <n>` after `--transformer` to train for a fixed number of epochs.
   You can also save and resume training with `--checkpoint <file>` which stores
-  a checkpoint every epoch (change the interval with `--checkpoint-freq`).
-  The model weights are periodically saved to
+  a checkpoint every epoch (change the interval with `--checkpoint-freq`). If an
+  existing file contains only model weights, the script will still load them but
+  the optimizer state will start from scratch. The model weights are periodically saved to
   `rl-baselines3-zoo/donkey_transformer.pt` by default. Use `--model-path` to
   change the location and `--save-freq` to control the saving interval.
   When training starts, the script automatically reloads weights from the last

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ This repository bundles [RL Baselines3 Zoo](https://github.com/DLR-RM/rl-baselin
    ./start_training.sh --transformer
    ```
 
-   By default, the example trains for 10 epochs. Pass `--epochs <n>` after
-   `--transformer` to change the number of epochs. You can also save and
+   By default, the example trains continuously until interrupted. Pass
+   `--epochs <n>` after `--transformer` to train for a fixed number of epochs.
+   You can also save and
    resume training with `--checkpoint <file>` which stores a checkpoint every
    epoch (change the interval with `--checkpoint-freq`).
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ This repository bundles [RL Baselines3 Zoo](https://github.com/DLR-RM/rl-baselin
 
    The script runs RL Baselines3 Zoo with the SAC algorithm on the `donkey-generated-track-v0` environment. Additional arguments will be forwarded to `train.py`.
 
+   To run the HuggingFace Transformer example, pass the `--transformer` flag (the setup script installs the required `transformers` package):
+
+   ```bash
+   ./start_training.sh --transformer
+   ```
+
    If you encounter an error about `donkey-generated-track-v0` not being found,
    make sure the `gym-donkeycar` package is installed (the setup script installs
    it automatically) or run training via `./start_training.sh` which adds the

--- a/README.md
+++ b/README.md
@@ -36,11 +36,15 @@ This repository bundles [RL Baselines3 Zoo](https://github.com/DLR-RM/rl-baselin
    ./start_training.sh --transformer
    ```
 
-   By default, the example trains continuously until interrupted. Pass
-   `--epochs <n>` after `--transformer` to train for a fixed number of epochs.
-   You can also save and
-   resume training with `--checkpoint <file>` which stores a checkpoint every
-   epoch (change the interval with `--checkpoint-freq`).
+  By default, the example trains continuously until interrupted. Pass
+  `--epochs <n>` after `--transformer` to train for a fixed number of epochs.
+  You can also save and resume training with `--checkpoint <file>` which stores
+  a checkpoint every epoch (change the interval with `--checkpoint-freq`).
+  The model weights are periodically saved to
+  `rl-baselines3-zoo/donkey_transformer.pt` by default. Use `--model-path` to
+  change the location and `--save-freq` to control the saving interval.
+  When training starts, the script automatically reloads weights from the last
+  saved file if present.
 
    If you encounter an error about `donkey-generated-track-v0` not being found,
    ensure the `gym-donkeycar` package is available. The provided scripts add it

--- a/gym-donkeycar/examples/huggingface_transformer/train_transformer.py
+++ b/gym-donkeycar/examples/huggingface_transformer/train_transformer.py
@@ -127,9 +127,14 @@ def main() -> None:
     start_epoch = 0
     if args.checkpoint and os.path.exists(args.checkpoint):
         ckpt = torch.load(args.checkpoint, map_location=device)
-        model.load_state_dict(ckpt["model"])
-        optim.load_state_dict(ckpt["optimizer"])
-        start_epoch = ckpt.get("epoch", 0)
+        if isinstance(ckpt, dict) and "model" in ckpt:
+            model.load_state_dict(ckpt["model"])
+            if "optimizer" in ckpt:
+                optim.load_state_dict(ckpt["optimizer"])
+            start_epoch = ckpt.get("epoch", 0)
+        else:
+            # Allow resuming from a plain state_dict file for convenience
+            model.load_state_dict(ckpt)
     elif args.model_path and os.path.exists(args.model_path):
         model.load_state_dict(torch.load(args.model_path, map_location=device))
 

--- a/gym-donkeycar/examples/huggingface_transformer/train_transformer.py
+++ b/gym-donkeycar/examples/huggingface_transformer/train_transformer.py
@@ -124,6 +124,11 @@ def main() -> None:
     optim = torch.optim.Adam(model.parameters(), lr=1e-4)
     loss_fn = nn.MSELoss()
 
+    if args.model_path:
+        os.makedirs(os.path.dirname(args.model_path), exist_ok=True)
+    if args.checkpoint:
+        os.makedirs(os.path.dirname(args.checkpoint), exist_ok=True)
+
     start_epoch = 0
     if args.checkpoint and os.path.exists(args.checkpoint):
         ckpt = torch.load(args.checkpoint, map_location=device)

--- a/gym-donkeycar/examples/huggingface_transformer/train_transformer.py
+++ b/gym-donkeycar/examples/huggingface_transformer/train_transformer.py
@@ -84,9 +84,12 @@ def main() -> None:
     parser.add_argument("--episodes", type=int, default=10)
     parser.add_argument("--seq-len", type=int, default=4)
     parser.add_argument("--batch-size", type=int, default=4)
-    # Train for more than one epoch by default so the example does not
-    # terminate immediately after data collection.
-    parser.add_argument("--epochs", type=int, default=10)
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=0,
+        help="Number of epochs to train. Set to 0 to run indefinitely.",
+    )
     parser.add_argument(
         "--checkpoint",
         default=None,
@@ -117,7 +120,8 @@ def main() -> None:
         optim.load_state_dict(ckpt["optimizer"])
         start_epoch = ckpt.get("epoch", 0)
 
-    for epoch in range(start_epoch, args.epochs):
+    epoch = start_epoch
+    while True:
         for frames, acts, next_action in loader:
             images = frames.to(device)
             actions = acts.to(device)
@@ -137,6 +141,10 @@ def main() -> None:
                 },
                 args.checkpoint,
             )
+
+        epoch += 1
+        if args.epochs and epoch >= args.epochs:
+            break
 
     torch.save(model.state_dict(), "donkey_transformer.pt")
 

--- a/gym-donkeycar/examples/huggingface_transformer/train_transformer.py
+++ b/gym-donkeycar/examples/huggingface_transformer/train_transformer.py
@@ -3,6 +3,10 @@ from collections import deque
 from typing import Deque, List, Tuple
 
 import gymnasium as gym
+# Import gym_donkeycar so its environments (e.g. donkey-generated-track-v0)
+# get registered with Gymnasium. Without this import gym.make() will fail to
+# locate the environment.
+import gym_donkeycar  # noqa: F401  (unused import needed for registration)
 import torch
 import torch.nn as nn
 from torch.utils.data import Dataset, DataLoader

--- a/gym-donkeycar/examples/huggingface_transformer/train_transformer.py
+++ b/gym-donkeycar/examples/huggingface_transformer/train_transformer.py
@@ -83,7 +83,9 @@ def main() -> None:
     parser.add_argument("--episodes", type=int, default=10)
     parser.add_argument("--seq-len", type=int, default=4)
     parser.add_argument("--batch-size", type=int, default=4)
-    parser.add_argument("--epochs", type=int, default=1)
+    # Train for more than one epoch by default so the example does not
+    # terminate immediately after data collection.
+    parser.add_argument("--epochs", type=int, default=10)
     args = parser.parse_args()
 
     env = gym.make(args.env)

--- a/rl-baselines3-zoo/requirements.txt
+++ b/rl-baselines3-zoo/requirements.txt
@@ -12,3 +12,4 @@ plotly
 # panda-gym~=3.0.1
 wandb
 moviepy>=1.0.0
+transformers

--- a/start_training.sh
+++ b/start_training.sh
@@ -31,6 +31,14 @@ fi
 
 if [[ "$1" == "--transformer" ]]; then
     shift
+    # Ensure transformers is installed when running the example
+    if ! python - <<'EOF' >/dev/null 2>&1
+import transformers
+EOF
+    then
+        echo "Error: transformers is not installed. Run 'pip install transformers' inside the virtualenv." >&2
+        exit 1
+    fi
     # Run the HuggingFace transformer example located in gym-donkeycar
     # Additional arguments are forwarded to the example script
     python "$SCRIPT_DIR/gym-donkeycar/examples/huggingface_transformer/train_transformer.py" "$@"

--- a/start_training.sh
+++ b/start_training.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# Start RL Baselines3 Zoo training for DonkeyCar
-# Usage: ./start_training.sh [additional train.py arguments]
+# Start RL Baselines3 Zoo training for DonkeyCar or train the HuggingFace
+# transformer example.
+# Usage: ./start_training.sh [--transformer [args...]] [additional train.py arguments]
 
 set -e
 
@@ -28,5 +29,12 @@ then
     exit 1
 fi
 
-python train.py --algo sac --env donkey-generated-track-v0 --gym-packages gym_donkeycar \
-       --eval-freq 10000 --eval-episodes 10 --n-eval-envs 1 "$@"
+if [[ "$1" == "--transformer" ]]; then
+    shift
+    # Run the HuggingFace transformer example located in gym-donkeycar
+    # Additional arguments are forwarded to the example script
+    python "$SCRIPT_DIR/gym-donkeycar/examples/huggingface_transformer/train_transformer.py" "$@"
+else
+    python train.py --algo sac --env donkey-generated-track-v0 --gym-packages gym_donkeycar \
+        --eval-freq 10000 --eval-episodes 10 --n-eval-envs 1 "$@"
+fi

--- a/start_training.sh
+++ b/start_training.sh
@@ -5,14 +5,11 @@
 
 set -e
 
-# Move to the rl-baselines3-zoo directory
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 cd "$SCRIPT_DIR"
 
 source venv/bin/activate
-
-cd "$SCRIPT_DIR/rl-baselines3-zoo"
 
 
 # Ensure the local gym-donkeycar package is on the Python path so
@@ -43,6 +40,7 @@ EOF
     # Additional arguments are forwarded to the example script
     python "$SCRIPT_DIR/gym-donkeycar/examples/huggingface_transformer/train_transformer.py" "$@"
 else
+    cd "$SCRIPT_DIR/rl-baselines3-zoo"
     python train.py --algo sac --env donkey-generated-track-v0 --gym-packages gym_donkeycar \
         --eval-freq 10000 --eval-episodes 10 --n-eval-envs 1 "$@"
 fi


### PR DESCRIPTION
## Summary
- allow calling a HuggingFace transformer example through `start_training.sh`
- add `--transformer` flag so the script runs `train_transformer.py`

## Testing
- `./start_training.sh --transformer --help` *(fails: venv not found)*

------
https://chatgpt.com/codex/tasks/task_e_684454e7fc548326b67e65c2cab09a48