### PR TITLE
Improve lane detection video helper

### DIFF
--- a/lane_detection_video.sh
+++ b/lane_detection_video.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+
+set -e
+
+MODEL_PATH="rl-baselines3-zoo/rl-trained-agents/sac/donkey-generated-track-v0.zip"
+
+if [ ! -f "$MODEL_PATH" ]; then
+    echo "Pre-trained agents not found at $MODEL_PATH." >&2
+    if [ ! -d "rl-baselines3-zoo/rl-trained-agents" ]; then
+        echo "Cloning rl-trained-agents repository..." >&2
+        git clone https://github.com/DLR-RM/rl-trained-agents rl-baselines3-zoo/rl-trained-agents
+    fi
+    ln -sf rl-baselines3-zoo/rl-trained-agents
+fi
+
 source venv/bin/activate
 python -m rl_zoo3.record_video --algo sac \
     --env donkey-generated-track-v0 \


### PR DESCRIPTION
## Summary
- check for pretrained model in `lane_detection_video.sh`
- automatically clone `rl-trained-agents` when missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gym')*

------
https://chatgpt.com/codex/tasks/task_e_6844f76b6ed88326836ba4a6c8620fef