### PR TITLE
Add default screenshot capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,20 @@ This repository bundles [RL Baselines3 Zoo](https://github.com/DLR-RM/rl-baselin
 
 5. **Optional screenshot capture**
 
-   The DonkeyCar environment supports saving raw camera images every few seconds
-   during training. Set `screenshot_interval` (in seconds) and `screenshot_dir`
-   in the environment configuration to enable this feature. Captured images are
-   stored in the specified directory for later inspection.
+The DonkeyCar environment saves raw camera images every two seconds by default
+into an `images` directory. Adjust `screenshot_interval` (in seconds) or
+`screenshot_dir` in the environment configuration to change this behaviour.
+
+   Example customizing the interval to capture a frame every five seconds:
+
+   ```python
+   import gym
+
+   conf = {
+       "exe_path": "/path/to/donkey_sim.exe",
+       "screenshot_interval": 5,
+   }
+
+   env = gym.make("donkey-generated-track-v0", conf=conf)
+   ```
 

--- a/gym-donkeycar/gym_donkeycar/envs/donkey_env.py
+++ b/gym-donkeycar/gym_donkeycar/envs/donkey_env.py
@@ -38,8 +38,10 @@ def supply_defaults(conf: Dict[str, Any]) -> None:
         ("steer_limit", 1.0),
         ("throttle_min", 0.0),
         ("throttle_max", 1.0),
-        ("screenshot_interval", 0),
-        ("screenshot_dir", "screenshots"),
+        # Enable screenshot capture by default every two seconds into
+        # the ``images`` directory so users can inspect raw frames.
+        ("screenshot_interval", 2),
+        ("screenshot_dir", "images"),
     ]
 
     for key, val in defaults:


### PR DESCRIPTION
## Summary
- enable screenshot capture every 2 seconds into an `images` folder by default
- document how to customise the screenshot interval

## Testing
- `pytest -q` *(fails: 38 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684581b41df08326b52e2620dbfd0001