### PR TITLE
Fix env kwargs quoting in training script

### DIFF
--- a/start_training.sh
+++ b/start_training.sh
@@ -42,5 +42,5 @@ EOF
 else
     cd "$SCRIPT_DIR/rl-baselines3-zoo"
     python train.py --algo sac --env donkey-generated-track-v0 --gym-packages gym_donkeycar \
-        --eval-freq 10000 --eval-episodes 10 --n-eval-envs 1 --env-kwargs screenshot_interval:5 screenshot_dir:images "$@"
+        --eval-freq 10000 --eval-episodes 10 --n-eval-envs 1 --env-kwargs screenshot_interval:5 screenshot_dir:"images" "$@"
 fi


### PR DESCRIPTION
## Summary
- quote `screenshot_dir` value correctly in `start_training.sh`

## Testing
- `bash -n start_training.sh`

------
https://chatgpt.com/codex/tasks/task_e_6845863884fc8326b031a5daba1a6576