### PR TITLE
Fix quoting of screenshot_dir argument

### DIFF
--- a/start_training.sh
+++ b/start_training.sh
@@ -42,5 +42,5 @@ EOF
 else
     cd "$SCRIPT_DIR/rl-baselines3-zoo"
     python train.py --algo sac --env donkey-generated-track-v0 --gym-packages gym_donkeycar \
-        --eval-freq 10000 --eval-episodes 10 --n-eval-envs 1 --env-kwargs screenshot_interval:5 screenshot_dir:"images" "$@"
+        --eval-freq 10000 --eval-episodes 10 --n-eval-envs 1 --env-kwargs screenshot_interval:5 screenshot_dir:'"images"' "$@"
 fi


### PR DESCRIPTION
## Summary
- quote screenshot_dir env-kwargs value in `start_training.sh`

## Testing
- `python -c 'import sys; print(sys.argv)' screenshot_dir:'"images"'`

------
https://chatgpt.com/codex/tasks/task_e_6845877e331c83269151eab7e159dc83