### PR TITLE
Fix screenshot kwargs for DonkeyCar training

### DIFF
--- a/start_training.sh
+++ b/start_training.sh
@@ -42,5 +42,6 @@ EOF
 else
     cd "$SCRIPT_DIR/rl-baselines3-zoo"
     python train.py --algo sac --env donkey-generated-track-v0 --gym-packages gym_donkeycar \
-        --eval-freq 10000 --eval-episodes 10 --n-eval-envs 1 --env-kwargs screenshot_interval:5 screenshot_dir:'"images"' "$@"
+        --eval-freq 10000 --eval-episodes 10 --n-eval-envs 1 \
+        --env-kwargs conf:"{\"screenshot_interval\": 5, \"screenshot_dir\": \"images\"}" "$@"
 fi


### PR DESCRIPTION
## Summary
- update training script to pass screenshot parameters inside `conf`

## Testing
- `python - <<'EOF'
import sys
try:
    import gymnasium as gym
    import gym_donkeycar
    conf={'screenshot_interval':5,'screenshot_dir':'images'}
    env = gym.make('donkey-generated-track-v0', conf=conf)
    print('Env', env)
except Exception as e:
    print('Exception:', e)
    sys.exit(1)
EOF` *(fails: No module named 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_684588b925708326af2944b9158afdf6